### PR TITLE
Added ftdetect file

### DIFF
--- a/ftdetect/nsis.vim
+++ b/ftdetect/nsis.vim
@@ -1,0 +1,7 @@
+" Vim ftplugin file
+" Language:    NSIS 2.46 script
+" Maintainer:  Chris Morgan <me@chrismorgan.info>
+" Last Change: 2012 March 5
+" Version:     2.46-2
+
+au BufNewFile,BufRead *.nsh set filetype=nsis


### PR DESCRIPTION
This way *.nsh files will automatically get the nsis filetype.

Tested and working when installed as a pathogen bundle.